### PR TITLE
Anonymize endpoint now expects array of texts instead of single string 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A privacy-focused Flask API server that combines Microsoft Presidio with the Est
 * **Estonian NER Support** : Integrates `tartuNLP/EstBERT_NER_v2` for Estonian named entity recognition
 * **Multilingual** : Supports Estonian via sPaCy
 * **Custom Estonian Patterns** : Recognizes Estonian-specific entities like personal codes (isikukood), car numbers, and phone numbers
+* **Batch Processing** : Process multiple texts in a single request for efficient anonymization
 * **Allowlist/Denylist Support** : Fine-tune detection by excluding false positives or forcing specific words to be detected as PII
 * **REST API** : Easy-to-use HTTP endpoints for text analysis and anonymization
 * **Docker Support** : Ready-to-deploy containerized application
@@ -60,10 +61,10 @@ docker-compose up --build -d
 3. Test the API:
 
 ```bash
-curl -X POST http://localhost:8000/analyze \
+curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Minu nimi on Jaan Tamm ja ma elan Tallinnas.",
+    "texts": ["Minu nimi on Jaan Tamm ja ma elan Tallinnas."],
     "language": "xx"
 }'
 ```
@@ -102,13 +103,23 @@ Returns API status and configuration information.
 POST /anonymize
 ```
 
-Analyzes and replaces PII entities with anonymized placeholders.
+Analyzes and replaces PII entities with anonymized placeholders. **Accepts an array of texts** and returns an array of results.
+
+**Batch Processing:**
+
+- Process multiple texts in a single request
+- Same configuration (anonymizers, allowlist, denylist) applies to all texts
+- Each text is processed independently
+- Results maintain the same order as input texts
 
 **Request Body:**
 
 ```json
 {
-  "text": "Minu nimi on Jaan Tamm ja ma elan Tallinnas. Projekti nimi on Butterfly.",
+  "texts": [
+    "Minu nimi on Jaan Tamm ja ma elan Tallinnas. Projekti nimi on Liblikas.",
+    "Mari Mets töötab Tartu Ülikoolis."
+  ],
   "language": "xx",
   "anonymizers": {
     "PERSON": {"type": "replace", "new_value": "[ISIK]"},
@@ -117,7 +128,7 @@ Analyzes and replaces PII entities with anonymized placeholders.
   },
   "entities": ["PERSON", "LOCATION"],
   "allowlist": ["Tallinn"],
-  "denylist": ["Butterfly"]
+  "denylist": ["Liblikas"]
 }
 ```
 
@@ -127,7 +138,7 @@ Apply the same anonymization to all detected entities:
 
 ```json
 {
-  "text": "Mu nimi on Mart Kask ja email on mart@example.com",
+  "texts": ["Mu nimi on Mart Kask ja email on mart@example.com"],
   "language": "xx",
   "anonymizers": {
     "DEFAULT": {
@@ -142,7 +153,7 @@ Or use `DEFAULT` with entity-specific overrides:
 
 ```json
 {
-  "text": "Contact John at john@example.com or call +372 5555 5555",
+  "texts": ["Võta ühendust Peeter Kukk, email peeter@example.com või helistades +372 5555 5555"],
   "language": "xx",
   "anonymizers": {
     "DEFAULT": {"type": "hash", "hash_type": "sha256"},
@@ -154,7 +165,7 @@ Or use `DEFAULT` with entity-specific overrides:
 
 **Parameters:**
 
-* `text` (required, string): Text to anonymize
+* `texts` (required, array of strings): **Array of texts to anonymize** - each text is processed independently
 * `language` (optional, string, default: "xx"): Language code
 * `anonymizers` (optional, object): Custom anonymization operators for each entity type
   * `type`: Anonymization method - "replace", "mask", "redact", or "encrypt"
@@ -169,25 +180,43 @@ Or use `DEFAULT` with entity-specific overrides:
 
 **Response:**
 
+Returns an array of results, one for each input text:
+
 ```json
 {
-  "items": [
+  "results": [
     {
-      "end": 22,
-      "entity_type": "PERSON",
-      "operator": "replace",
-      "start": 13,
-      "text": "[ISIK]"
+      "text": "Minu nimi on [ISIK] ja ma elan Tallinnas. Projekti nimi on [KONFIDENTSIAALNE].",
+      "items": [
+        {
+          "end": 22,
+          "entity_type": "PERSON",
+          "operator": "replace",
+          "start": 13,
+          "text": "[ISIK]"
+        },
+        {
+          "end": 76,
+          "entity_type": "DENYLIST_MATCH",
+          "operator": "replace",
+          "start": 67,
+          "text": "[KONFIDENTSIAALNE]"
+        }
+      ]
     },
     {
-      "end": 76,
-      "entity_type": "DENYLIST_MATCH",
-      "operator": "replace",
-      "start": 67,
-      "text": "[KONFIDENTSIAALNE]"
+      "text": "[ISIK] töötab Tartu Ülikoolis.",
+      "items": [
+        {
+          "end": 10,
+          "entity_type": "PERSON",
+          "operator": "replace",
+          "start": 0,
+          "text": "[ISIK]"
+        }
+      ]
     }
-  ],
-  "text": "Minu nimi on [ISIK] ja ma elan Tallinnas. Project codename is [KONFIDENTSIAALNE]."
+  ]
 }
 ```
 
@@ -200,13 +229,13 @@ Presidio supports multiple anonymization methods. You can specify operators per 
 ```json
    {
      "anonymizers": {
-       "PERSON": {"type": "replace", "new_value": "[PERSON]"},
-       "DEFAULT": {"type": "replace", "new_value": "[REDACTED]"}
+       "PERSON": {"type": "replace", "new_value": "[ISIK]"},
+       "DEFAULT": {"type": "replace", "new_value": "[VARJATUD]"}
      }
    }
 ```
 
-1. **Redact** : Completely remove the PII text
+2. **Redact** : Completely remove the PII text
 
 ```json
    {
@@ -218,7 +247,7 @@ Presidio supports multiple anonymization methods. You can specify operators per 
 
 * Removes the entity entirely from the text
 
-1. **Mask** : Replace characters with masking character
+3. **Mask** : Replace characters with masking character
 
 ```json
    {
@@ -237,7 +266,7 @@ Presidio supports multiple anonymization methods. You can specify operators per 
 * `chars_to_mask`: Number of characters to mask
 * `from_end`: Whether to mask from the end (default: `true`)
 
-1. **Hash** : Replace with cryptographic hash
+4. **Hash** : Replace with cryptographic hash
 
 ```json
    {
@@ -253,7 +282,7 @@ Presidio supports multiple anonymization methods. You can specify operators per 
 * `hash_type`: Hash algorithm - `sha256`, `sha512`, or `md5`
 * Produces consistent hash for same input
 
-1. **Encrypt** : Replace with AES encrypted value (reversible)
+5. **Encrypt** : Replace with AES encrypted value (reversible)
 
 ```json
    {
@@ -269,7 +298,7 @@ Presidio supports multiple anonymization methods. You can specify operators per 
 * `key`: 128-bit, 192-bit, or 256-bit encryption key
 * Allows decryption with the same key
 
-1. **Keep** : Retain original value (no anonymization)
+6. **Keep** : Retain original value (no anonymization)
 
 ```json
    {
@@ -299,7 +328,7 @@ Returns list of all entity types that can be detected for a given language.
 {
   "entities": ["PERSON", "ORGANIZATION", "LOCATION", "EMAIL_ADDRESS", ...],
   "language": "xx",
-  "count": 16
+  "count": 15
 }
 ```
 
@@ -321,7 +350,7 @@ Returns list of all active recognizers for a given language.
 {
   "recognizers": ["EstBERT_NER_Recognizer", "EstonianPersonalCode", "EstonianPhoneNumbers", ...],
   "language": "xx",
-  "count": 10
+  "count": 18
 }
 ```
 
@@ -355,18 +384,18 @@ Use the allowlist to prevent common words or domain-specific terms from being fl
 **Example: Company and product names**
 
 ```bash
-curl -X POST http://localhost:8000/analyze \
+curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Microsoft Azure is used by Acme Corp for cloud services.",
-    "allowlist": ["Microsoft", "Azure", "Acme Corp"]
+    "texts": ["Microsoft Azure teenust kasutab Eesti Energia oma pilvelahenduste jaoks."],
+    "allowlist": ["Microsoft", "Azure", "Eesti Energia"]
   }'
 ```
 
 **Use cases:**
 
 * Company names that shouldn't be anonymized
-* Common place names (e.g., "Tallinn", "Estonia")
+* Common place names (e.g., "Tallinn", "Tartu")
 * Product names or brands
 * Technical terms that trigger false positives
 
@@ -380,10 +409,10 @@ Use the denylist to ensure specific sensitive terms are always detected as PII:
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Project Falcon is scheduled for Q3. Contact Alpha team.",
-    "denylist": ["Falcon", "Alpha"],
+    "texts": ["Projekt Öökull on salastatud. Võta ühendust Kaarel Kasega detailide osas."],
+    "denylist": ["Öökull", "salastatud"],
     "anonymizers": {
-      "DENYLIST_MATCH": {"type": "replace", "new_value": "[REDACTED]"}
+      "DENYLIST_MATCH": {"type": "replace", "new_value": "[VARJATUD]"}
     }
   }'
 ```
@@ -401,18 +430,18 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "John Smith from Microsoft works on Project Phoenix in Tallinn.",
-    "allowlist": ["Microsoft", "Tallinn"],
-    "denylist": ["Phoenix"],
+    "texts": ["Jaan Tamm Microsoft Eesti esindusest töötab projektil Phönix Tallinnas."],
+    "allowlist": ["Microsoft Eesti", "Tallinn"],
+    "denylist": ["Phönix"],
     "entities": ["PERSON", "ORGANIZATION", "LOCATION"]
   }'
 ```
 
 **Result:**
 
-* "John Smith" → anonymized (detected as PERSON)
-* "Microsoft" → kept (in allowlist)
-* "Phoenix" → anonymized (in denylist)
+* "Jaan Tamm" → anonymized (detected as PERSON)
+* "Microsoft Eesti" → kept (in allowlist)
+* "Phönix" → anonymized (in denylist)
 * "Tallinn" → kept (in allowlist)
 
 ## Configuration
@@ -525,7 +554,6 @@ services:
       - TRANSFORMERS_CACHE=/root/.cache/huggingface
     volumes:
       - ./config:/app/config
-      - stanza_cache:/root/stanza_resources
       - transformers_cache:/root/.cache/huggingface
     deploy:
       resources:
@@ -586,7 +614,22 @@ The container includes built-in health checks that verify API availability:
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Jaan Tamm (isikukood: 38001085718) töötab AS Eesti Firma juures Tallinnas.",
+    "texts": ["Jaan Tamm (isikukood: 38001085718) töötab AS Eesti Firma juures Tallinnas."],
+    "language": "xx"
+  }'
+```
+
+**Batch Processing Multiple Texts:**
+
+```bash
+curl -X POST http://localhost:8000/anonymize \
+  -H "Content-Type: application/json" \
+  -d '{
+    "texts": [
+      "Jaan Tamm (isikukood: 38001085718) töötab AS Eesti Firma juures Tallinnas.",
+      "Mari Mets saadab emaili mari.mets@example.ee",
+      "Kontakttelefon: +372 5555 5555"
+    ],
     "language": "xx"
   }'
 ```
@@ -599,7 +642,7 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Mu nimi on Mart Kask ja email on mart@example.com",
+    "texts": ["Mu nimi on Mart Kask ja email on mart.kask@example.ee"],
     "language": "xx",
     "anonymizers": {
       "DEFAULT": {
@@ -614,8 +657,12 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "Mu nimi on [XXX] ja email on [XXX]",
-  "items": [...]
+  "results": [
+    {
+      "text": "Mu nimi on [XXX] ja email on [XXX]",
+      "items": [...]
+    }
+  ]
 }
 ```
 
@@ -625,7 +672,7 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Mu nimi on Mart Kask",
+    "texts": ["Mu nimi on Mart Kask ja elan Tartus"],
     "language": "xx",
     "anonymizers": {
       "DEFAULT": {
@@ -640,8 +687,12 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "Mu nimi on 8c9a6b5e3d2f1a4b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
-  "items": [...]
+  "results": [
+    {
+      "text": "Mu nimi on 8c9a6b5e3d2f1a4b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b ja elan 3f8a2c9d1e4b7a5c8d0f2e1b3a6c9d7e4f8a2b5c1d3e6f9a0b2c5d8e1f4a7b",
+      "items": [...]
+    }
+  ]
 }
 ```
 
@@ -651,13 +702,19 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Mu nimi on Mart Kask",
+    "texts": ["Võta ühendust Kalle Kallasega telefonil +372 5123 4567"],
     "language": "xx",
     "anonymizers": {
-      "DEFAULT": {
+      "PERSON": {
         "type": "mask",
         "masking_char": "*",
-        "chars_to_mask": 5,
+        "chars_to_mask": 6,
+        "from_end": true
+      },
+      "PHONE_NUMBER": {
+        "type": "mask",
+        "masking_char": "X",
+        "chars_to_mask": 4,
         "from_end": true
       }
     }
@@ -668,8 +725,12 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "Mu nimi on Mart*****",
-  "items": [...]
+  "results": [
+    {
+      "text": "Võta ühendust Kalle K****** telefonil +372 5123 XXXX",
+      "items": [...]
+    }
+  ]
 }
 ```
 
@@ -679,11 +740,11 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Contact Kalle Kask at kalle@example.com",
+    "texts": ["Võta ühendust Kalle Kask aadressil kalle@example.ee"],
     "language": "xx",
     "anonymizers": {
       "PERSON": {"type": "redact"},
-      "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL REMOVED]"}
+      "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL EEMALDATUD]"}
     }
   }'
 ```
@@ -692,8 +753,12 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "Contact  at [EMAIL REMOVED]",
-  "items": [...]
+  "results": [
+    {
+      "text": "Võta ühendust  aadressil [EMAIL EEMALDATUD]",
+      "items": [...]
+    }
+  ]
 }
 ```
 
@@ -703,7 +768,7 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Confidential ID: 38001085718",
+    "texts": ["Töötaja isikukood: 38001085718"],
     "language": "xx",
     "anonymizers": {
       "EE_PERSONAL_CODE": {
@@ -720,10 +785,10 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Contact Mari Maasikas at mari@example.com or +372 5555 5555",
+    "texts": ["Võta ühendust Mari Maasikas aadressil mari.maasikas@example.ee või helistades +372 5555 5555"],
     "language": "xx",
     "anonymizers": {
-      "PERSON": {"type": "replace", "new_value": "[NAME]"},
+      "PERSON": {"type": "replace", "new_value": "[NIMI]"},
       "EMAIL_ADDRESS": {"type": "hash", "hash_type": "sha256"},
       "PHONE_NUMBER": {"type": "mask", "masking_char": "X", "chars_to_mask": 4, "from_end": true}
     }
@@ -734,8 +799,12 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "Contact [NAME] at a3b2c1d4e5f6... or +372 5555 XXXX",
-  "items": [...]
+  "results": [
+    {
+      "text": "Võta ühendust [NIMI] aadressil a3b2c1d4e5f6... või helistades +372 5555 XXXX",
+      "items": [...]
+    }
+  ]
 }
 ```
 
@@ -745,11 +814,11 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "John Smith lives in Tallinn. Email: john@example.com, Phone: +372 5555 5555",
+    "texts": ["Jaan Tamm elab Tallinnas. Email: jaan.tamm@example.ee, Telefon: +372 5555 5555"],
     "language": "xx",
     "anonymizers": {
       "DEFAULT": {"type": "hash", "hash_type": "sha256"},
-      "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL PROTECTED]"},
+      "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL KAITSTUD]"},
       "LOCATION": {"type": "keep"}
     }
   }'
@@ -759,20 +828,26 @@ curl -X POST http://localhost:8000/anonymize \
 
 ```json
 {
-  "text": "a1b2c3d4e5f6... lives in Tallinn. Email: [EMAIL PROTECTED], Phone: f9e8d7c6b5a4...",
-  "items": [...]
+  "results": [
+    {
+      "text": "a1b2c3d4e5f6... elab Tallinnas. Email: [EMAIL KAITSTUD], Telefon: f9e8d7c6b5a4...",
+      "items": [...]
+    }
+  ]
 }
 ```
 
 ### Allowlist and Denylist Examples
 
+**Using Allowlist to Preserve Important Terms:**
+
 ```bash
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Mari Maasikas from Estonian Business Registry works in Tallinn.",
+    "texts": ["Mari Maasikas Äriregistri esindusest töötab Tallinnas."],
     "language": "xx",
-    "allowlist": ["Estonian Business Registry", "Tallinn"]
+    "allowlist": ["Äriregister", "Tallinn"]
   }'
 ```
 
@@ -782,9 +857,9 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Project Nightingale is classified. Contact Sarah for details.",
+    "texts": ["Projekt Öökull on salastatud. Võta ühendust Kaarel Kasega detailide osas."],
     "language": "xx",
-    "denylist": ["Nightingale", "classified"]
+    "denylist": ["Öökull", "salastatud"]
   }'
 ```
 
@@ -794,19 +869,33 @@ curl -X POST http://localhost:8000/anonymize \
 curl -X POST http://localhost:8000/anonymize \
   -H "Content-Type: application/json" \
   -d '{
-    "text": "Contact Kalle Kask at Microsoft Estonia about Project Phoenix. Meeting in Tallinn tomorrow.",
+    "texts": [
+      "Võta ühendust Kalle Kask Microsoft Eesti esindusest projektiga Phönix seoses. Kohtumine Tallinnas homme.",
+      "Mari Mets töötab samuti projektil Phönix meie Tartu kontorist."
+    ],
     "language": "xx",
-    "allowlist": ["Microsoft Estonia", "Tallinn"],
-    "denylist": ["Phoenix"],
+    "allowlist": ["Microsoft Eesti", "Tallinn", "Tartu"],
+    "denylist": ["Phönix"],
     "anonymizers": {
-      "PERSON": {"type": "replace", "new_value": "[NAME]"},
-      "DENYLIST_MATCH": {"type": "replace", "new_value": "[CLASSIFIED]"}
+      "PERSON": {"type": "replace", "new_value": "[NIMI]"},
+      "DENYLIST_MATCH": {"type": "replace", "new_value": "[SALASTATUD]"}
     }
   }'
 ```
 
 **Result:**
 
-```
-Contact [NAME] at Microsoft Estonia about Project [CLASSIFIED]. Meeting in Tallinn tomorrow.
+```json
+{
+  "results": [
+    {
+      "text": "Võta ühendust [NIMI] Microsoft Eesti esindusest projektiga [SALASTATUD] seoses. Kohtumine Tallinnas homme.",
+      "items": [...]
+    },
+    {
+      "text": "[NIMI] töötab samuti projektil [SALASTATUD] meie Tartu kontorist.",
+      "items": [...]
+    }
+  ]
+}
 ```

--- a/app.py
+++ b/app.py
@@ -13,11 +13,12 @@ from presidio_anonymizer import AnonymizerEngine
 from presidio_anonymizer.entities import OperatorConfig
 
 from utils import synthesize_all
+
 # Import your custom configuration loader
 from presidio_flask_estbert import (
     load_presidio_from_config,
     validate_config,
-    analyze_with_lists
+    analyze_with_lists,
 )
 
 # Configure logging
@@ -41,45 +42,46 @@ WELCOME_MESSAGE = r"""
                                                               
 """
 
+
 class EstonianPresidioFlaskServer:
     """Flask server for Presidio with Estonian EstBERT support"""
-    
+
     def __init__(self, config_path: str = "/app/config/presidio-spacy-estbert.yml"):
         self.config_path = config_path
         self.app = Flask(__name__)
-        
+
         # Initialize Flask-RESTX with proper configuration
         self.api = Api(
-            self.app, 
-            version="1.0", 
+            self.app,
+            version="1.0",
             title="Estonian Presidio API",
             description="API for PII detection and anonymization using EstBERT + spaCy with allowlist/denylist support",
             doc="/docs/",  # Swagger UI will be available at /docs/
             validate=True,  # Enable request validation
-            ordered=True   # Keep endpoint order in documentation
+            ordered=True,  # Keep endpoint order in documentation
         )
-        
+
         # Enable CORS
         CORS(self.app)
-        
+
         # Configure Flask
-        self.app.config['JSON_AS_ASCII'] = False  # Support for Estonian characters
-        self.app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
-        
+        self.app.config["JSON_AS_ASCII"] = False  # Support for Estonian characters
+        self.app.config["JSONIFY_PRETTYPRINT_REGULAR"] = True
+
         # Initialize engines
         self._initialize_engines()
-        
+
         # Define API models
         self._define_api_models()
-        
+
         # Setup routes using Flask-RESTX
         self._setup_routes()
-        
+
         # Setup error handlers
         self._setup_error_handlers()
-        
+
         logger.info(WELCOME_MESSAGE)
-    
+
     def _initialize_engines(self):
         """Initialize Presidio analyzer and anonymizer engines"""
         try:
@@ -87,139 +89,175 @@ class EstonianPresidioFlaskServer:
             is_valid, message = validate_config(self.config_path)
             if not is_valid:
                 raise ValueError(f"Invalid configuration: {message}")
-            
+
             # Load configuration
-            with open(self.config_path, 'r', encoding='utf-8') as f:
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 self.config = yaml.safe_load(f)
-            
+
             # Initialize analyzer with EstBERT + spaCy
             logger.info("Initializing Presidio Analyzer with EstBERT + spaCy...")
             self.analyzer = load_presidio_from_config(self.config_path)
-            
+
             # Initialize anonymizer
             logger.info("Initializing Presidio Anonymizer...")
             self.anonymizer = AnonymizerEngine()
-            
+
             logger.info("Presidio engines initialized successfully")
-            
+
         except Exception as e:
             logger.error(f"Failed to initialize Presidio engines: {e}")
             raise
-    
+
     def _define_api_models(self):
         """Define Flask-RESTX models for request/response validation and documentation"""
-        
+
         # Health check response model
-        self.health_model = self.api.model('HealthResponse', {
-            'status': fields.String(required=True, description='Service status', example='healthy'),
-            'service': fields.String(required=True, description='Service name', example='Estonian Presidio API'),
-            'version': fields.String(required=True, description='API version', example='1.0.0'),
-            'supported_languages': fields.List(fields.String, description='Supported languages', example=['et']),
-            'model': fields.String(description='Model information', example='tartuNLP/EstBERT_NER + spaCy')
-        })
+        self.health_model = self.api.model(
+            "HealthResponse",
+            {
+                "status": fields.String(
+                    required=True, description="Service status", example="healthy"
+                ),
+                "service": fields.String(
+                    required=True,
+                    description="Service name",
+                    example="Estonian Presidio API",
+                ),
+                "version": fields.String(
+                    required=True, description="API version", example="1.0.0"
+                ),
+                "supported_languages": fields.List(
+                    fields.String, description="Supported languages", example=["et"]
+                ),
+                "model": fields.String(
+                    description="Model information",
+                    example="tartuNLP/EstBERT_NER + spaCy",
+                ),
+            },
+        )
 
         # Anonymizer operator models for better documentation
-        self.operator_replace_model = self.api.model('ReplaceOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type',
-                example='replace',
-                enum=['replace']
-            ),
-            'new_value': fields.String(
-                required=True,
-                description='Text to replace the PII with',
-                example='[PERSON]'
-            )
-        })
-        
-        self.operator_redact_model = self.api.model('RedactOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type - completely removes the PII',
-                example='redact',
-                enum=['redact']
-            )
-        })
-        
-        self.operator_mask_model = self.api.model('MaskOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type',
-                example='mask',
-                enum=['mask']
-            ),
-            'masking_char': fields.String(
-                required=True,
-                description='Character to use for masking',
-                example='*',
-                default='*'
-            ),
-            'chars_to_mask': fields.Integer(
-                required=True,
-                description='Number of characters to mask',
-                example=4
-            ),
-            'from_end': fields.Boolean(
-                description='Mask from the end of the string (true) or beginning (false)',
-                example=True,
-                default=True
-            )
-        })
-        
-        self.operator_hash_model = self.api.model('HashOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type - creates deterministic hash (same input = same hash)',
-                example='hash',
-                enum=['hash']
-            ),
-            'hash_type': fields.String(
-                required=True,
-                description='Hash algorithm to use',
-                example='sha256',
-                enum=['sha256', 'sha512', 'md5'],
-                default='sha256'
-            )
-        })
-        
-        self.operator_encrypt_model = self.api.model('EncryptOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type - AES encryption (reversible with same key)',
-                example='encrypt',
-                enum=['encrypt']
-            ),
-            'key': fields.String(
-                required=True,
-                description='Encryption key (16, 24, or 32 characters for 128, 192, or 256-bit encryption)',
-                example='WmZq4t7w!z%C&F)J'
-            )
-        })
-        
-        self.operator_keep_model = self.api.model('KeepOperator', {
-            'type': fields.String(
-                required=True,
-                description='Operator type - keeps original text unchanged',
-                example='keep',
-                enum=['keep']
-            )
-        })
-        
-        # Anonymization request model
-        self.anonymize_request_model = self.api.model('AnonymizeRequest', {
-            'text': fields.String(
-                required=True, 
-                description='Text to analyze and anonymize',
-                example='Kontakt Jaan Tamm email jaan@example.com või telefon +372 5555 5555'
-            ),
-            'language': fields.String(
-                default='xx', 
-                description='Language code',
-                example='xx'
-            ),
-            'anonymizers': fields.Raw(
-                description='''Custom anonymization operators per entity type or DEFAULT for all entities.
+        self.operator_replace_model = self.api.model(
+            "ReplaceOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type",
+                    example="replace",
+                    enum=["replace"],
+                ),
+                "new_value": fields.String(
+                    required=True,
+                    description="Text to replace the PII with",
+                    example="[PERSON]",
+                ),
+            },
+        )
+
+        self.operator_redact_model = self.api.model(
+            "RedactOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type - completely removes the PII",
+                    example="redact",
+                    enum=["redact"],
+                )
+            },
+        )
+
+        self.operator_mask_model = self.api.model(
+            "MaskOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type",
+                    example="mask",
+                    enum=["mask"],
+                ),
+                "masking_char": fields.String(
+                    required=True,
+                    description="Character to use for masking",
+                    example="*",
+                    default="*",
+                ),
+                "chars_to_mask": fields.Integer(
+                    required=True, description="Number of characters to mask", example=4
+                ),
+                "from_end": fields.Boolean(
+                    description="Mask from the end of the string (true) or beginning (false)",
+                    example=True,
+                    default=True,
+                ),
+            },
+        )
+
+        self.operator_hash_model = self.api.model(
+            "HashOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type - creates deterministic hash (same input = same hash)",
+                    example="hash",
+                    enum=["hash"],
+                ),
+                "hash_type": fields.String(
+                    required=True,
+                    description="Hash algorithm to use",
+                    example="sha256",
+                    enum=["sha256", "sha512", "md5"],
+                    default="sha256",
+                ),
+            },
+        )
+
+        self.operator_encrypt_model = self.api.model(
+            "EncryptOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type - AES encryption (reversible with same key)",
+                    example="encrypt",
+                    enum=["encrypt"],
+                ),
+                "key": fields.String(
+                    required=True,
+                    description="Encryption key (16, 24, or 32 characters for 128, 192, or 256-bit encryption)",
+                    example="WmZq4t7w!z%C&F)J",
+                ),
+            },
+        )
+
+        self.operator_keep_model = self.api.model(
+            "KeepOperator",
+            {
+                "type": fields.String(
+                    required=True,
+                    description="Operator type - keeps original text unchanged",
+                    example="keep",
+                    enum=["keep"],
+                )
+            },
+        )
+
+        # Anonymization request model - NOW WITH ARRAY OF TEXTS
+        self.anonymize_request_model = self.api.model(
+            "AnonymizeRequest",
+            {
+                "texts": fields.List(
+                    fields.String,
+                    required=True,
+                    description="Array of strings to analyze and anonymize",
+                    example=[
+                        "Kontakt Jaan Tamm email jaan@example.com või telefon +372 5555 5555",
+                        "Mari Mets elab Tallinnas",
+                    ],
+                ),
+                "language": fields.String(
+                    default="xx", description="Language code", example="xx"
+                ),
+                "anonymizers": fields.Raw(
+                    description="""Custom anonymization operators per entity type or DEFAULT for all entities.
                 
 Available operators:
 - replace: {"type": "replace", "new_value": "[REDACTED]"}
@@ -230,113 +268,140 @@ Available operators:
 - keep: {"type": "keep"} - no anonymization
 
 Use "DEFAULT" to apply operator to all entities, or specify per entity type.
-Entity-specific operators override DEFAULT.''',
-                example={
-                    "DEFAULT": {"type": "replace", "new_value": "[REDACTED]"},
-                    "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL]"},
-                    "PHONE_NUMBER": {"type": "mask", "masking_char": "X", "chars_to_mask": 4, "from_end": True}
-                }
-            ),
-            'entities': fields.List(
-                fields.String, 
-                description='Specific entity types to anonymize (if not provided, uses all configured)',
-                example=['PERSON', 'EMAIL_ADDRESS', 'PHONE_NUMBER']
-            ),
-            'allowlist': fields.List(
-                fields.String, 
-                description='Words/phrases to exclude from anonymization (case-insensitive)',
-                example=['Microsoft', 'Tallinn']
-            ),
-            'denylist': fields.List(
-                fields.String, 
-                description='Words/phrases to force anonymization as DENYLIST_MATCH (case-insensitive)',
-                example=['Project Phoenix', 'confidential']
-            )
-        })
-        
-        # Anonymization item model
-        self.anonymization_item_model = self.api.model('AnonymizationItem', {
-            'start': fields.Integer(
-                required=True, 
-                description='Start position of original PII in text',
-                example=8
-            ),
-            'end': fields.Integer(
-                required=True, 
-                description='End position of original PII in text',
-                example=17
-            ),
-            'entity_type': fields.String(
-                required=True, 
-                description='Type of entity that was anonymized',
-                example='PERSON'
-            ),
-            'text': fields.String(
-                required=True, 
-                description='The anonymized/replacement text',
-                example='[PERSON]'
-            ),
-            'operator': fields.String(
-                required=True, 
-                description='Operator used for anonymization',
-                example='replace'
-            )
-        })
-        
-        # Anonymization response model
-        self.anonymize_response_model = self.api.model('AnonymizeResponse', {
-            'text': fields.String(
-                required=True, 
-                description='Fully anonymized text with all PII replaced',
-                example='Contact [PERSON] at [EMAIL] or call XXXX'
-            ),
-            'items': fields.List(
-                fields.Nested(self.anonymization_item_model), 
-                description='List of all anonymization operations performed'
-            )
-        })
-        
+Entity-specific operators override DEFAULT.""",
+                    example={
+                        "DEFAULT": {"type": "replace", "new_value": "[REDACTED]"},
+                        "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL]"},
+                        "PHONE_NUMBER": {
+                            "type": "mask",
+                            "masking_char": "X",
+                            "chars_to_mask": 4,
+                            "from_end": True,
+                        },
+                    },
+                ),
+                "entities": fields.List(
+                    fields.String,
+                    description="Specific entity types to anonymize (if not provided, uses all configured)",
+                    example=["PERSON", "EMAIL_ADDRESS", "PHONE_NUMBER"],
+                ),
+                "allowlist": fields.List(
+                    fields.String,
+                    description="Words/phrases to exclude from anonymization (case-insensitive)",
+                    example=["Microsoft", "Tallinn"],
+                ),
+                "denylist": fields.List(
+                    fields.String,
+                    description="Words/phrases to force anonymization as DENYLIST_MATCH (case-insensitive)",
+                    example=["Project Phoenix", "confidential"],
+                ),
+            },
+        )
+
+        # Anonymization item model (for individual PII entities found)
+        self.anonymization_item_model = self.api.model(
+            "AnonymizationItem",
+            {
+                "start": fields.Integer(
+                    required=True,
+                    description="Start position of original PII in text",
+                    example=8,
+                ),
+                "end": fields.Integer(
+                    required=True,
+                    description="End position of original PII in text",
+                    example=17,
+                ),
+                "entity_type": fields.String(
+                    required=True,
+                    description="Type of entity that was anonymized",
+                    example="PERSON",
+                ),
+                "text": fields.String(
+                    required=True,
+                    description="The anonymized/replacement text",
+                    example="[PERSON]",
+                ),
+                "operator": fields.String(
+                    required=True,
+                    description="Operator used for anonymization",
+                    example="replace",
+                ),
+            },
+        )
+
+        # Single text result model
+        self.single_anonymize_result_model = self.api.model(
+            "SingleAnonymizeResult",
+            {
+                "text": fields.String(
+                    required=True,
+                    description="Fully anonymized text with all PII replaced",
+                    example="Contact [PERSON] at [EMAIL] or call XXXX",
+                ),
+                "items": fields.List(
+                    fields.Nested(self.anonymization_item_model),
+                    description="List of all anonymization operations performed on this text",
+                ),
+            },
+        )
+
+        # Array response model - ARRAY OF RESULTS
+        self.anonymize_response_model = self.api.model(
+            "AnonymizeResponse",
+            {
+                "results": fields.List(
+                    fields.Nested(self.single_anonymize_result_model),
+                    required=True,
+                    description="Array of anonymization results, one for each input text",
+                )
+            },
+        )
+
         # Error model
-        self.error_model = self.api.model('Error', {
-            'error': fields.String(
-                required=True, 
-                description='Error message describing what went wrong',
-                example='Missing required field: text'
-            )
-        })
-    
+        self.error_model = self.api.model(
+            "Error",
+            {
+                "error": fields.String(
+                    required=True,
+                    description="Error message describing what went wrong",
+                    example="Missing required field: texts",
+                )
+            },
+        )
+
     def _setup_error_handlers(self):
         """Setup Flask error handlers"""
-        
+
         @self.app.errorhandler(HTTPException)
         def handle_http_exception(error):
             logger.error(f"HTTP error: {error}")
             return jsonify(error=str(error)), error.code
-        
+
         @self.app.errorhandler(Exception)
         def handle_generic_exception(error):
             logger.error(f"Unexpected error: {error}")
             return jsonify(error="Internal server error"), 500
-    
+
     def _setup_routes(self):
         """Setup Flask-RESTX routes with proper documentation"""
-        
+
         logger.info("Setting up routes...")
-        
+
         # Store reference to self for use in route handlers
         server_instance = self
-        
+
         # Test route to verify Flask is working
         @self.app.route("/test")
         def test_route():
             return jsonify({"status": "test route works"})
-        
+
         # Health Check Route
         @self.api.route("/health")
         class HealthCheck(Resource):
             @self.api.doc(
-                'health_check',
-                description='Health check endpoint - verify API is running and get service information'
+                "health_check",
+                description="Health check endpoint - verify API is running and get service information",
             )
             @self.api.marshal_with(server_instance.health_model, code=200)
             def get(resource_self):
@@ -346,25 +411,29 @@ Entity-specific operators override DEFAULT.''',
                     "status": "healthy",
                     "service": "Estonian Presidio API",
                     "version": "1.0.0",
-                    "supported_languages": server_instance.config.get("supported_languages", ["xx"]),
-                    "model": "tartuNLP/EstBERT_NER + spaCy"
+                    "supported_languages": server_instance.config.get(
+                        "supported_languages", ["xx"]
+                    ),
+                    "model": "tartuNLP/EstBERT_NER + spaCy",
                 }, 200
-        
-        logger.info(f"Routes registered: {[rule.rule for rule in self.app.url_map.iter_rules()]}")
-        
 
-           
-        # Anonymize Route  
+        logger.info(
+            f"Routes registered: {[rule.rule for rule in self.app.url_map.iter_rules()]}"
+        )
+
+        # Anonymize Route
         @self.api.route("/anonymize")
         class Anonymize(Resource):
             @self.api.doc(
-                'anonymize_text',
-                description='''
-**Tuvasta ja anonümiseeri isikuandmed tekstis kasutades konfigureeritavaid operaatoreid.**
+                "anonymize_text",
+                description="""
+**Tuvasta ja anonümiseeri isikuandmed tekstides kasutades konfigureeritavaid operaatoreid.**
 
-See endpoint teostab kaks toimingut:
-1. **Analüüs**: Tuvastab isikuandmed kasutades EstBERT + spaCy mudeleid (sama mis /analyze)
+See endpoint teostab kaks toimingut iga teksti kohta:
+1. **Analüüs**: Tuvastab isikuandmed kasutades EstBERT + spaCy mudeleid
 2. **Anonümiseerimine**: Muudab tuvastatud isikuandmed vastavalt määratud operaatoritele
+
+**OLULINE: Endpoint võtab vastu MASSIIVI tekstidest ja tagastab MASSIIVI tulemusi.**
 
 **Saadaolevad anonümiseerimise operaatorid:**
 
@@ -382,11 +451,14 @@ See endpoint teostab kaks toimingut:
 - Kirjuta üle entiteedi-spetsiifiliste operaatoritega
 - Näide: Räsi kõik, välja arvatud e-mailid
 
-**Operaatori näited:**
+**Operaatori näited massiividega:**
 ```json
-// Lihtne asendamine kõigile entiteetidele
+// Lihtne asendamine kõigile entiteetidele mitme tekstiga
 {
-  "text": "Kontakt Jaan Tamm email jaan@example.com või telefon +372 5555 5555",
+  "texts": [
+    "Kontakt Jaan Tamm email jaan@example.com või telefon +372 5555 5555",
+    "Mari Mets elab Tallinnas aadressil Liivalaia 2"
+  ],
   "anonymizers": {
     "DEFAULT": {"type": "replace", "new_value": "[VARJATUD]"}
   }
@@ -394,53 +466,24 @@ See endpoint teostab kaks toimingut:
 
 // Räsi kõik, aga asenda e-mailid
 {
-  "text": "Töötaja Mari Mets (mari.mets@firma.ee) isikukood 39012315678",
+  "texts": [
+    "Töötaja Mari Mets (mari.mets@firma.ee) isikukood 39012315678",
+    "Kontakt Peeter Kukk aadressil peeter@mail.ee"
+  ],
   "anonymizers": {
     "DEFAULT": {"type": "hash", "hash_type": "sha256"},
     "EMAIL_ADDRESS": {"type": "replace", "new_value": "[EMAIL]"}
   }
 }
 
-// Varjata telefoninumbrid (viimased 4 numbrit nähtavad)
-{
-  "text": "Helista Kalle Kallasele telefonil +372 5123 4567",
-  "anonymizers": {
-    "PHONE_NUMBER": {
-      "type": "mask",
-      "masking_char": "X",
-      "chars_to_mask": 8,
-      "from_end": false
-    }
-  }
-}
-
-// Krüpteerimine pööratavas vormis
-{
-  "text": "Töötaja isikukood on 38906123456",
-  "anonymizers": {
-    "EE_PERSONAL_CODE": {
-      "type": "encrypt",
-      "key": "WmZq4t7w!z%C&F)J"
-    }
-  }
-}
-
-// Entiteedi-spetsiifilised operaatorid
-{
-  "text": "Peeter Kukk (peeter@mail.ee, tel +372 5555 1234) elab Tallinnas",
-  "anonymizers": {
-    "PERSON": {"type": "replace", "new_value": "[NIMI]"},
-    "EMAIL_ADDRESS": {"type": "hash", "hash_type": "sha256"},
-    "PHONE_NUMBER": {"type": "mask", "masking_char": "*", "chars_to_mask": 4},
-    "LOCATION": {"type": "keep"}
-  }
-}
-
 // Lubatud sõnade ja keelatud sõnade kasutamine
 {
-  "text": "Microsoft töötaja Jaan Tamm projektis Phoenix saadab maili aadressil jaan@microsoft.com",
-  "allowlist": ["Microsoft", "Tallinn"],  // Ei anonümiseerita neid sõnu
-  "denylist": ["Phoenix"],  // Anonümiseeritakse alati kui DENYLIST_MATCH
+  "texts": [
+    "Microsoft töötaja Jaan Tamm projektis Phoenix saadab maili aadressil jaan@microsoft.com",
+    "Tallinna kontoris töötab Mari Mets projektis Phoenix"
+  ],
+  "allowlist": ["Microsoft", "Tallinn"],
+  "denylist": ["Phoenix"],
   "anonymizers": {
     "DEFAULT": {"type": "replace", "new_value": "[PII]"},
     "PERSON": {"type": "replace", "new_value": "[ISIK]"}
@@ -450,46 +493,65 @@ See endpoint teostab kaks toimingut:
 
 **Sisendparameetrid:**
 
-- **text** (nõutud): Tekst, mida analüüsida ja anonümiseerida
-- **language** (valikuline, vaikimisi "xx"): Keele kood
+- **texts** (nõutud): List tekstidest, mida analüüsida ja anonümiseerida
+- **language** (valikuline, vaikimisi "xx"): Keele kood, hetkel sobib xx (mitmekeelne/EstBERT)
 - **anonymizers** (valikuline): Anonümiseerimise operaatorid entiteedi tüüpide kaupa või DEFAULT kõigile
-- **entities** (valikuline): Konkreetsed entiteedi tüübid, mida anonümiseerida (kui puudub, kasutatakse kõiki konfigureeritud)
-- **allowlist** (valikuline): Sõnad/fraasid, mida EI anonümiseerita (tõstutundetu). Need sõnad sünteesitakse automaatselt kõigis käänetes kasutades EstNLTK Vabamorf teeki, et arvestada eesti keele morfoloogiaga. Näiteks "Microsoft" → ["Microsoft", "Microsofti", "Microsoftis", ...]. See tagab, et ettevõtte nimed ja muud olulised terminid jäävad kõigis vormides anonüümimata.
-- **denylist** (valikuline): Sõnad/fraasid, mida ALATI anonümiseeritakse kui DENYLIST_MATCH (tõstutundetu). Nagu allowlist, sünteesitakse ka denylist sõnad automaatselt kõigis eesti keele käänetes. Näiteks konfidentsiaalse projekti nimi "Phoenix" → ["Phoenix", "Phoenixi", "Phoenixis", ...]. See võimaldab tuvastada ja varjata konfidentsiaalset informatsiooni sõltumata grammatilisest vormist tekstis.
+- **entities** (valikuline): Konkreetsed entiteedi tüübid, mida anonümiseerida
+- **allowlist** (valikuline): Sõnad/fraasid, mida EI anonümiseerita (automaatne käänamine)
+- **denylist** (valikuline): Sõnad/fraasid, mida ALATI anonümiseeritakse (automaatne käänamine)
 
-**Käändeliste vormide süntees:**
+**Väljund:**
 
-API kasutab EstNLTK Vabamorf teeki, et genereerida automaatselt kõik käändelised vormid (14 käänet × 2 arvu = 28 vormi) allowlist ja denylist sõnadele. See on oluline eesti keele puhul, kus sõnad muutuvad lauses:
-- "Microsoft" → "Microsofti", "Microsoftis", "Microsoftile", jne
-- "Tallinn" → "Tallinna", "Tallinnas", "Tallinnast", jne
-
-Tänu sellele ei pea kasutaja ise kõiki vorme sisestama - piisab põhivormist.
+Endpoint tagastab `results` massiivi, kus iga element vastab ühele sisendtekstile:
+```json
+{
+  "results": [
+    {
+      "text": "Kontakt [PERSON] email [EMAIL] või telefon XXXX",
+      "items": [
+        {"start": 8, "end": 16, "entity_type": "PERSON", "text": "[PERSON]", "operator": "replace"},
+        {"start": 23, "end": 30, "entity_type": "EMAIL_ADDRESS", "text": "[EMAIL]", "operator": "replace"}
+      ]
+    },
+    {
+      "text": "[PERSON] elab [LOCATION] aadressil Liivalaia 2",
+      "items": [...]
+    }
+  ]
+}
 ```
-
-
-                '''
+                """,
             )
             @self.api.expect(server_instance.anonymize_request_model)
             @self.api.marshal_with(server_instance.anonymize_response_model, code=200)
-            @self.api.response(400, 'Bad Request', server_instance.error_model)
-            @self.api.response(500, 'Internal Server Error', server_instance.error_model)
+            @self.api.response(400, "Bad Request", server_instance.error_model)
+            @self.api.response(
+                500, "Internal Server Error", server_instance.error_model
+            )
             def post(resource_self):
                 """
-                Analyze and anonymize text using EstBERT + spaCy
+                Analyze and anonymize multiple texts using EstBERT + spaCy
                 """
                 try:
                     logger.info("Anonymize endpoint called")
                     # Parse request JSON
                     if not request.is_json:
                         server_instance.api.abort(400, "Request must be JSON")
-                    
+
                     data = request.get_json()
-                    
-                    # Validate required fields
-                    if "text" not in data:
-                        server_instance.api.abort(400, "Missing required field: text")
-                    
-                    text = data["text"]
+
+                    if "texts" not in data:
+                        server_instance.api.abort(400, "Missing required field: texts")
+
+                    texts = data["texts"]
+
+                    # Validate that texts is a list
+                    if not isinstance(texts, list):
+                        server_instance.api.abort(400, "Field 'texts' must be an array")
+
+                    if len(texts) == 0:
+                        server_instance.api.abort(400, "Field 'texts' cannot be empty")
+
                     language = data.get("language", "xx")
                     anonymizers = data.get("anonymizers")
                     entities = data.get("entities")
@@ -497,33 +559,35 @@ Tänu sellele ei pea kasutaja ise kõiki vorme sisestama - piisab põhivormist.
                     allowlist = synthesize_all(allowlist)
                     denylist = data.get("denylist", [])
                     denylist = synthesize_all(denylist)
-                    
+
                     # Use entities from request or default from config
-                    entities_to_detect = entities or server_instance.config.get('entities_to_detect', [
-                        "PERSON", "ORGANIZATION", "LOCATION", "DATE_TIME",
-                        "EMAIL_ADDRESS", "PHONE_NUMBER", "URL", "IP_ADDRESS", "GPE"
-                    ])
-                    
-                    # Analyze text with allowlist/denylist support
-                    analyzer_results = analyze_with_lists(
-                        analyzer=server_instance.analyzer,
-                        text=text,
-                        entities=entities_to_detect,
-                        language=language,
-                        allowlist=allowlist if allowlist else None,
-                        denylist=denylist if denylist else None
+                    entities_to_detect = entities or server_instance.config.get(
+                        "entities_to_detect",
+                        [
+                            "PERSON",
+                            "ORGANIZATION",
+                            "LOCATION",
+                            "DATE_TIME",
+                            "EMAIL_ADDRESS",
+                            "PHONE_NUMBER",
+                            "URL",
+                            "IP_ADDRESS",
+                            "GPE",
+                        ],
                     )
-                    
-                    # Setup anonymization operators
+
+                    # Setup anonymization operators (same for all texts)
                     operators = {}
                     if anonymizers:
                         # Use custom anonymizers from request
                         for entity_type, config in anonymizers.items():
                             operator_type = config.get("type", "replace")
                             params = {}
-                            
+
                             if operator_type == "replace":
-                                params["new_value"] = config.get("new_value", f"<{entity_type}>")
+                                params["new_value"] = config.get(
+                                    "new_value", f"<{entity_type}>"
+                                )
                             elif operator_type == "mask":
                                 params["masking_char"] = config.get("masking_char", "*")
                                 params["chars_to_mask"] = config.get("chars_to_mask", 4)
@@ -532,52 +596,82 @@ Tänu sellele ei pea kasutaja ise kõiki vorme sisestama - piisab põhivormist.
                                 pass  # No parameters needed for redact
                             elif operator_type == "encrypt":
                                 params["key"] = config.get("key", "")
-                            
-                            operators[entity_type] = OperatorConfig(operator_type, params)
+
+                            operators[entity_type] = OperatorConfig(
+                                operator_type, params
+                            )
                     else:
                         # Use default Estonian anonymizers from config
-                        default_anonymizers = server_instance.config.get('anonymization_config', {}).get('default_operators', {})
+                        default_anonymizers = server_instance.config.get(
+                            "anonymization_config", {}
+                        ).get("default_operators", {})
                         for entity_type, replacement in default_anonymizers.items():
-                            operators[entity_type] = OperatorConfig("replace", {"new_value": replacement})
-                        
+                            operators[entity_type] = OperatorConfig(
+                                "replace", {"new_value": replacement}
+                            )
+
                         # Add default operator for DENYLIST_MATCH if not configured
                         if "DENYLIST_MATCH" not in operators:
-                            operators["DENYLIST_MATCH"] = OperatorConfig("replace", {"new_value": "[PII]"})
-                    
-                    # Anonymize the text
-                    anonymized_result = server_instance.anonymizer.anonymize(
-                        text=text,
-                        analyzer_results=analyzer_results,
-                        operators=operators
-                    )
-                    
-                    # Convert items to JSON format
-                    items_json = []
-                    for item in anonymized_result.items:
-                        items_json.append({
-                            "start": item.start,
-                            "end": item.end,
-                            "entity_type": item.entity_type,
-                            "text": item.text,
-                            "operator": item.operator
-                        })
-                    
-                    return {
-                        "text": anonymized_result.text,
-                        "items": items_json
-                    }, 200
-                    
+                            operators["DENYLIST_MATCH"] = OperatorConfig(
+                                "replace", {"new_value": "[PII]"}
+                            )
+
+                    # Process each text in the array
+                    results_array = []
+
+                    for idx, text in enumerate(texts):
+                        logger.info(f"Processing text {idx + 1}/{len(texts)}")
+
+                        # Analyze text with allowlist/denylist support
+                        analyzer_results = analyze_with_lists(
+                            analyzer=server_instance.analyzer,
+                            text=text,
+                            entities=entities_to_detect,
+                            language=language,
+                            allowlist=allowlist if allowlist else None,
+                            denylist=denylist if denylist else None,
+                        )
+
+                        # Anonymize the text
+                        anonymized_result = server_instance.anonymizer.anonymize(
+                            text=text,
+                            analyzer_results=analyzer_results,
+                            operators=operators,
+                        )
+
+                        # Convert items to JSON format
+                        items_json = []
+                        for item in anonymized_result.items:
+                            items_json.append(
+                                {
+                                    "start": item.start,
+                                    "end": item.end,
+                                    "entity_type": item.entity_type,
+                                    "text": item.text,
+                                    "operator": item.operator,
+                                }
+                            )
+
+                        # Add this text's result to the array
+                        results_array.append(
+                            {"text": anonymized_result.text, "items": items_json}
+                        )
+
+                    logger.info(f"Successfully processed {len(results_array)} texts")
+
+                    return {"results": results_array}, 200
+
                 except Exception as e:
                     error_msg = f"Anonymization failed: {str(e)}"
                     logger.error(error_msg)
                     server_instance.api.abort(500, error_msg)
-        
+
         # Recognizers Route
         @self.api.route("/recognizers")
         class Recognizers(Resource):
             @self.api.doc(
-                'get_recognizers',
-                description='''
+                "get_recognizers",
+                description="""
 **Get list of all active recognizers for a language.**
 
 Recognizers are the detection engines that identify different types of PII:
@@ -600,33 +694,39 @@ Recognizers are the detection engines that identify different types of PII:
   "count": 6
 }
 ```
-                '''
+                """,
             )
-            @self.api.param('language', 'Language code (default: xx)', type='string', default='xx')
+            @self.api.param(
+                "language", "Language code (default: xx)", type="string", default="xx"
+            )
             def get(resource_self):
                 """Get list of available recognizers for a language"""
                 try:
                     language = request.args.get("language", "xx")
-                    recognizers_list = server_instance.analyzer.get_recognizers(language)
-                    recognizer_names = [recognizer.name for recognizer in recognizers_list]
-                    
+                    recognizers_list = server_instance.analyzer.get_recognizers(
+                        language
+                    )
+                    recognizer_names = [
+                        recognizer.name for recognizer in recognizers_list
+                    ]
+
                     return {
                         "recognizers": recognizer_names,
                         "language": language,
-                        "count": len(recognizer_names)
+                        "count": len(recognizer_names),
                     }, 200
-                    
+
                 except Exception as e:
                     error_msg = f"Failed to get recognizers: {str(e)}"
                     logger.error(error_msg)
                     server_instance.api.abort(500, error_msg)
-        
+
         # Supported Entities Route
         @self.api.route("/supportedentities")
         class SupportedEntities(Resource):
             @self.api.doc(
-                'get_supported_entities',
-                description='''
+                "get_supported_entities",
+                description="""
 **Get list of all entity types that can be detected.**
 
 Returns all supported PII entity types including:
@@ -669,32 +769,41 @@ Returns all supported PII entity types including:
   "count": 15
 }
 ```
-                '''
+                """,
             )
-            @self.api.param('language', 'Language code (default: xx)', type='string', default='xx')
+            @self.api.param(
+                "language", "Language code (default: xx)", type="string", default="xx"
+            )
             def get(resource_self):
                 """Get list of supported entities for a language"""
                 try:
                     language = request.args.get("language", "xx")
-                    entities_list = server_instance.analyzer.get_supported_entities(language)
-                    
+                    entities_list = server_instance.analyzer.get_supported_entities(
+                        language
+                    )
+                    configured_entities = server_instance.config.get(
+                        "entities_to_detect", []
+                    )
+                    filtered_entities = [
+                        e for e in entities_list if e in configured_entities
+                    ]
                     return {
-                        "entities": entities_list,
+                        "entities": filtered_entities,
                         "language": language,
-                        "count": len(entities_list)
+                        "count": len(filtered_entities),
                     }, 200
-                    
+
                 except Exception as e:
                     error_msg = f"Failed to get supported entities: {str(e)}"
                     logger.error(error_msg)
                     server_instance.api.abort(500, error_msg)
-        
+
         # Configuration Route
         @self.api.route("/config")
         class Configuration(Resource):
             @self.api.doc(
-                'get_configuration',
-                description='''
+                "get_configuration",
+                description="""
 **Get current API configuration (excluding sensitive information).**
 
 Returns the active configuration including:
@@ -723,37 +832,51 @@ Returns the active configuration including:
   ]
 }
 ```
-                '''
+                """,
             )
             def get(resource_self):
                 """Get current API configuration (excluding sensitive data)"""
                 try:
                     safe_config = {
-                        "supported_languages": server_instance.config.get("supported_languages"),
-                        "default_score_threshold": server_instance.config.get("default_score_threshold"),
-                        "entities_to_detect": server_instance.config.get("entities_to_detect"),
-                        "estbert_model": server_instance.config.get("estbert_configuration", {}).get("model_name"),
-                        "nlp_engine": server_instance.config.get("nlp_configuration", {}).get("nlp_engine_name"),
+                        "supported_languages": server_instance.config.get(
+                            "supported_languages"
+                        ),
+                        "default_score_threshold": server_instance.config.get(
+                            "default_score_threshold"
+                        ),
+                        "entities_to_detect": server_instance.config.get(
+                            "entities_to_detect"
+                        ),
+                        "estbert_model": server_instance.config.get(
+                            "estbert_configuration", {}
+                        ).get("model_name"),
+                        "nlp_engine": server_instance.config.get(
+                            "nlp_configuration", {}
+                        ).get("nlp_engine_name"),
                         "custom_recognizers": [
                             {
                                 "name": rec.get("name"),
                                 "type": rec.get("type"),
-                                "supported_entity": rec.get("supported_entity")
+                                "supported_entity": rec.get("supported_entity"),
                             }
-                            for rec in server_instance.config.get("custom_recognizers", [])
-                        ]
+                            for rec in server_instance.config.get(
+                                "custom_recognizers", []
+                            )
+                        ],
                     }
                     return safe_config, 200
-                    
+
                 except Exception as e:
                     error_msg = f"Failed to get configuration: {str(e)}"
                     logger.error(error_msg)
                     server_instance.api.abort(500, error_msg)
-        
+
         logger.info("All routes setup complete")
+
 
 # Global server instance
 server = None
+
 
 # Application factory
 def create_app(config_path: str = "/app/config/presidio-spacy-estbert.yml") -> Flask:
@@ -766,29 +889,43 @@ def create_app(config_path: str = "/app/config/presidio-spacy-estbert.yml") -> F
         logger.error(f"Failed to create application: {e}")
         raise
 
+
 # For running directly
 if __name__ == "__main__":
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Estonian Presidio API Server")
     parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
-    parser.add_argument("--port", type=int, default=int(os.getenv("PORT", DEFAULT_PORT)), help="Port to bind to")
-    parser.add_argument("--config", default="/app/config/presidio-spacy-estbert.yml", help="Configuration file path")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        help="Port to bind to",
+    )
+    parser.add_argument(
+        "--config",
+        default="/app/config/presidio-spacy-estbert.yml",
+        help="Configuration file path",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
-    
+
     args = parser.parse_args()
-    
+
     # Create Flask app
     app = create_app(args.config)
-    
-    logger.info(f"Starting Estonian Presidio Flask API server on {args.host}:{args.port}")
-    logger.info(f"Swagger documentation will be available at http://{args.host}:{args.port}/docs/")
-    
+
+    logger.info(
+        f"Starting Estonian Presidio Flask API server on {args.host}:{args.port}"
+    )
+    logger.info(
+        f"Swagger documentation will be available at http://{args.host}:{args.port}/docs/"
+    )
+
     # Run Flask app
     app.run(
         host=args.host,
         port=args.port,
         debug=args.debug,
-        threaded=True, 
-        use_reloader=False
+        threaded=True,
+        use_reloader=False,
     )

--- a/presidio_flask_estbert.py
+++ b/presidio_flask_estbert.py
@@ -1,6 +1,11 @@
 import yaml
 from transformers import AutoTokenizer, AutoModelForTokenClassification, pipeline
-from presidio_analyzer import AnalyzerEngine, RecognizerResult, PatternRecognizer, Pattern
+from presidio_analyzer import (
+    AnalyzerEngine,
+    RecognizerResult,
+    PatternRecognizer,
+    Pattern,
+)
 from presidio_analyzer.nlp_engine import NlpArtifacts, NlpEngineProvider
 from presidio_analyzer.entity_recognizer import EntityRecognizer
 from typing import List, Optional
@@ -11,18 +16,20 @@ logger = logging.getLogger("presidio-flask-api")
 
 class EstBERTRecognizer(EntityRecognizer):
     """Custom recognizer for tartuNLP/EstBERT_NER model"""
-    
+
     ENTITIES = ["PERSON", "ORGANIZATION", "LOCATION", "DATE_TIME", "GPE"]
-    
-    def __init__(self, model_name: str = "tartuNLP/EstBERT_NER", supported_language: str = "xx"):
+
+    def __init__(
+        self, model_name: str = "tartuNLP/EstBERT_NER", supported_language: str = "xx"
+    ):
         super().__init__(
             supported_entities=self.ENTITIES,
             supported_language=supported_language,
-            name="EstBERT_NER_Recognizer"
+            name="EstBERT_NER_Recognizer",
         )
-        
+
         logger.info(f"Loading EstBERT model: {model_name}")
-        
+
         try:
             self.tokenizer = AutoTokenizer.from_pretrained(model_name, max_length=512)
             self.model = AutoModelForTokenClassification.from_pretrained(model_name)
@@ -30,19 +37,21 @@ class EstBERTRecognizer(EntityRecognizer):
                 "ner",
                 model=self.model,
                 tokenizer=self.tokenizer,
-                aggregation_strategy="simple"
+                aggregation_strategy="simple",
             )
-            
+
             self.label_mapping = {
                 "PER": "PERSON",
                 "ORG": "ORGANIZATION",
                 "LOC": "LOCATION",
                 "GPE": "GPE",
                 "DATE": "DATE_TIME",
-                "TIME": "DATE_TIME"
+                "TIME": "DATE_TIME",
             }
-            
-            logger.info(f"✓ EstBERT recognizer initialized for language: {supported_language}")
+
+            logger.info(
+                f" EstBERT recognizer initialized for language: {supported_language}"
+            )
         except Exception as e:
             logger.error(f"✗ Failed to initialize EstBERT recognizer: {e}")
             raise
@@ -51,134 +60,154 @@ class EstBERTRecognizer(EntityRecognizer):
         """Load method - required by Presidio"""
         pass
 
-    def analyze(self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None) -> List[RecognizerResult]:
+    def analyze(
+        self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None
+    ) -> List[RecognizerResult]:
         """Analyze text using EstBERT NER model"""
         results = []
-        
+
         if not text or not text.strip():
             return results
-        
+
         try:
             ner_results = self.nlp_pipeline(text)
-            
+
             for entity in ner_results:
-                entity_type = entity.get('entity_group', entity.get('entity', '')).replace('B-', '').replace('I-', '')
+                entity_type = (
+                    entity.get("entity_group", entity.get("entity", ""))
+                    .replace("B-", "")
+                    .replace("I-", "")
+                )
                 presidio_entity = self.label_mapping.get(entity_type, entity_type)
-                
+
                 if presidio_entity in entities:
                     result = RecognizerResult(
                         entity_type=presidio_entity,
-                        start=entity['start'],
-                        end=entity['end'],
-                        score=entity['score']
+                        start=entity["start"],
+                        end=entity["end"],
+                        score=entity["score"],
                     )
                     results.append(result)
-                    
+
         except Exception as e:
             logger.error(f"Error in EstBERT analysis: {e}")
-            
+
         return results
 
 
 class DenylistRecognizer(EntityRecognizer):
     """Custom recognizer for denylist words"""
-    
-    def __init__(self, denylist: List[str], entity_type: str = "DENYLIST_MATCH", score: float = 1.0, supported_language: str = "xx"):
+
+    def __init__(
+        self,
+        denylist: List[str],
+        entity_type: str = "DENYLIST_MATCH",
+        score: float = 1.0,
+        supported_language: str = "xx",
+    ):
         super().__init__(
             supported_entities=[entity_type],
             supported_language=supported_language,
-            name="Denylist_Recognizer"
+            name="Denylist_Recognizer",
         )
         self.denylist = [word.lower() for word in denylist]
         self.entity_type = entity_type
         self.score = score
-    
+
     def load(self) -> None:
         """Load method - required by Presidio"""
         pass
-    
-    def analyze(self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None) -> List[RecognizerResult]:
+
+    def analyze(
+        self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts = None
+    ) -> List[RecognizerResult]:
         """Find denylist words in text"""
         results = []
         text_lower = text.lower()
-        
+
         for word in self.denylist:
             start = 0
             while True:
                 start = text_lower.find(word, start)
                 if start == -1:
                     break
-                
+
                 end = start + len(word)
                 is_start_boundary = start == 0 or not text[start - 1].isalnum()
                 is_end_boundary = end == len(text) or not text[end].isalnum()
-                
+
                 if is_start_boundary and is_end_boundary:
                     result = RecognizerResult(
                         entity_type=self.entity_type,
                         start=start,
                         end=end,
-                        score=self.score
+                        score=self.score,
                     )
                     results.append(result)
-                
+
                 start = end
-        
+
         return results
 
 
-def apply_allowlist(results: List[RecognizerResult], text: str, allowlist: List[str]) -> List[RecognizerResult]:
+def apply_allowlist(
+    results: List[RecognizerResult], text: str, allowlist: List[str]
+) -> List[RecognizerResult]:
     """Filter out results that match words in the allowlist"""
     if not allowlist:
         return results
-    
+
     allowlist_lower = [word.lower() for word in allowlist]
     filtered_results = []
-    
+
     for result in results:
-        detected_text = text[result.start:result.end].lower()
+        detected_text = text[result.start : result.end].lower()
         if detected_text not in allowlist_lower:
             filtered_results.append(result)
         else:
             logger.debug(f"Filtered out '{detected_text}' due to allowlist")
-    
+
     return filtered_results
 
 
 def create_pattern_recognizers(config: dict, language: str) -> List[PatternRecognizer]:
     """Create pattern-based recognizers from configuration"""
     recognizers = []
-    recognizers_config = config.get('recognizers', [])
-    
-    logger.info(f"Creating {len(recognizers_config)} pattern recognizers for language '{language}'")
-    
+    recognizers_config = config.get("recognizers", [])
+
+    logger.info(
+        f"Creating {len(recognizers_config)} pattern recognizers for language '{language}'"
+    )
+
     for rec_config in recognizers_config:
         try:
-            name = rec_config.get('name')
-            supported_entity = rec_config.get('supported_entity')
-            patterns_config = rec_config.get('patterns', [])
-            
+            name = rec_config.get("name")
+            supported_entity = rec_config.get("supported_entity")
+            patterns_config = rec_config.get("patterns", [])
+
             patterns = []
             for pattern_config in patterns_config:
                 pattern = Pattern(
-                    name=pattern_config.get('name'),
-                    regex=pattern_config.get('regex'),
-                    score=pattern_config.get('score', 0.5)
+                    name=pattern_config.get("name"),
+                    regex=pattern_config.get("regex"),
+                    score=pattern_config.get("score", 0.5),
                 )
                 patterns.append(pattern)
-            
+
             recognizer = PatternRecognizer(
                 supported_entity=supported_entity,
                 patterns=patterns,
                 name=name,
-                supported_language=language
+                supported_language=language,
             )
             recognizers.append(recognizer)
             logger.info(f"  ✓ Created: {name} for {supported_entity}")
-            
+
         except Exception as e:
-            logger.error(f"  ✗ Failed to create {rec_config.get('name', 'unknown')}: {e}")
-    
+            logger.error(
+                f"  ✗ Failed to create {rec_config.get('name', 'unknown')}: {e}"
+            )
+
     return recognizers
 
 
@@ -187,84 +216,89 @@ def load_presidio_from_config(config_path: str):
     logger.info("=" * 80)
     logger.info("LOADING PRESIDIO ANALYZER")
     logger.info("=" * 80)
-    
-    with open(config_path, 'r', encoding='utf-8') as f:
+
+    with open(config_path, "r", encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
-    supported_languages = config.get('supported_languages', ['xx'])
+    supported_languages = config.get("supported_languages", ["xx"])
     logger.info(f"Supported languages: {supported_languages}")
-    
+
     # Create NLP engine
     logger.info("Creating NLP engine...")
     try:
-        nlp_provider = NlpEngineProvider(nlp_configuration=config['nlp_configuration'])
+        nlp_provider = NlpEngineProvider(nlp_configuration=config["nlp_configuration"])
         nlp_engine = nlp_provider.create_engine()
-        logger.info("✓ NLP engine created")
+        logger.info(" NLP engine created")
     except Exception as e:
-        logger.error(f"✗ NLP engine creation failed: {e}")
+        logger.error(f" NLP engine creation failed: {e}")
         raise
-    
+
     # Create analyzer WITHOUT registry (we'll add recognizers manually)
     logger.info("Creating AnalyzerEngine...")
     analyzer = AnalyzerEngine(
         nlp_engine=nlp_engine,
         supported_languages=supported_languages,
-        default_score_threshold=config.get('default_score_threshold', 0.8)
+        default_score_threshold=config.get("default_score_threshold", 0.8),
     )
-    logger.info("✓ AnalyzerEngine created")
-    
+    logger.info(" AnalyzerEngine created")
+    unwanted_recognizers = ["MedicalLicenseRecognizer"]
+    for recognizer_name in unwanted_recognizers:
+        try:
+            analyzer.registry.remove_recognizer(recognizer_name)
+            logger.info(f"  Removed unwanted recognizer: {recognizer_name}")
+        except Exception as e:
+            logger.debug(f"  Could not remove {recognizer_name}: {e}")
     # Add recognizers for EACH supported language
     for lang in supported_languages:
         logger.info(f"\nAdding recognizers for language: {lang}")
-        
+
         # 1. Add EstBERT recognizer
         try:
-            estbert_config = config.get('estbert_configuration', {})
-            model_name = estbert_config.get('model_name', 'tartuNLP/EstBERT_NER')
+            estbert_config = config.get("estbert_configuration", {})
+            model_name = estbert_config.get("model_name", "tartuNLP/EstBERT_NER")
             estbert_recognizer = EstBERTRecognizer(
-                model_name=model_name,
-                supported_language=lang
+                model_name=model_name, supported_language=lang
             )
             analyzer.registry.add_recognizer(estbert_recognizer)
-            logger.info(f"  ✓ EstBERT recognizer added")
+            logger.info("   EstBERT recognizer added")
         except Exception as e:
-            logger.error(f"  ✗ EstBERT recognizer failed: {e}")
-        
+            logger.error(f"   EstBERT recognizer failed: {e}")
+
         # 2. Add pattern recognizers
         try:
             pattern_recognizers = create_pattern_recognizers(config, lang)
             for recognizer in pattern_recognizers:
                 analyzer.registry.add_recognizer(recognizer)
-            logger.info(f"  ✓ {len(pattern_recognizers)} pattern recognizers added")
+            logger.info(f"   {len(pattern_recognizers)} pattern recognizers added")
         except Exception as e:
-            logger.error(f"  ✗ Pattern recognizers failed: {e}")
-    
+            logger.error(f"   Pattern recognizers failed: {e}")
+
     # Verify recognizers were added
     logger.info("\n" + "=" * 80)
     logger.info("VERIFICATION")
     logger.info("=" * 80)
-    
+
     for lang in supported_languages:
         try:
             recognizers = analyzer.get_recognizers(lang)
             entities = analyzer.get_supported_entities(lang)
-            
+
             logger.info(f"\nLanguage: {lang}")
             logger.info(f"  Recognizers ({len(recognizers)}):")
             for rec in recognizers:
                 logger.info(f"    - {rec.name}")
             logger.info(f"  Entities ({len(entities)}): {entities}")
-            
+
             if len(recognizers) == 0:
-                logger.error(f"  ⚠️  WARNING: No recognizers for language {lang}!")
-                
+                logger.error(f"    WARNING: No recognizers for language {lang}!")
+
         except Exception as e:
-            logger.error(f"  ✗ Error verifying {lang}: {e}")
-    
+            logger.error(f"   Error verifying {lang}: {e}")
+
     logger.info("\n" + "=" * 80)
     logger.info("ANALYZER READY")
     logger.info("=" * 80 + "\n")
-    
+
     return analyzer
 
 
@@ -276,29 +310,29 @@ def analyze_with_lists(
     allowlist: Optional[List[str]] = None,
     denylist: Optional[List[str]] = None,
     return_decision_process: bool = False,
-    correlation_id: Optional[str] = None
+    correlation_id: Optional[str] = None,
 ) -> List[RecognizerResult]:
     """Analyze text with allowlist and denylist support"""
-    
-    logger.info(f"analyze_with_lists:")
+
+    logger.info("analyze_with_lists:")
     logger.info(f"  Text length: {len(text)}")
     logger.info(f"  Language: {language}")
     logger.info(f"  Entities: {entities}")
-    
+
     # Check recognizers BEFORE analysis
     try:
         recognizers = analyzer.get_recognizers(language)
         logger.info(f"  Available recognizers: {len(recognizers)}")
-        
+
         if len(recognizers) == 0:
             error_msg = f"No recognizers registered for language '{language}'. This is a configuration error."
             logger.error(error_msg)
             raise ValueError(error_msg)
-            
+
     except Exception as e:
         logger.error(f"  Failed to get recognizers: {e}")
         raise
-    
+
     # Run analysis
     try:
         results = analyzer.analyze(
@@ -306,49 +340,50 @@ def analyze_with_lists(
             entities=entities,
             language=language,
             return_decision_process=return_decision_process,
-            correlation_id=correlation_id
+            correlation_id=correlation_id,
         )
         logger.info(f"  Found {len(results)} entities")
     except Exception as e:
         logger.error(f"  Analysis failed: {e}", exc_info=True)
         raise
-    
+
     # Apply allowlist
     if allowlist:
-        original_count = len(results)
         results = apply_allowlist(results, text, allowlist)
         logger.info(f"  After allowlist: {len(results)} entities")
-    
+
     # Add denylist
     if denylist:
         denylist_recognizer = DenylistRecognizer(
-            denylist=denylist,
-            entity_type="DENYLIST_MATCH",
-            supported_language=language
+            denylist=denylist, entity_type="DENYLIST_MATCH", supported_language=language
         )
         denylist_results = denylist_recognizer.analyze(text, ["DENYLIST_MATCH"])
         logger.info(f"  Denylist found: {len(denylist_results)} entities")
         results.extend(denylist_results)
-    
+
     results.sort(key=lambda x: x.start)
     logger.info(f"  Final: {len(results)} entities")
-    
+
     return results
 
 
 def validate_config(config_path: str) -> tuple:
     """Validate Presidio configuration file"""
     try:
-        with open(config_path, 'r', encoding='utf-8') as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
-        
-        required_sections = ['supported_languages', 'nlp_configuration', 'estbert_configuration']
-        
+
+        required_sections = [
+            "supported_languages",
+            "nlp_configuration",
+            "estbert_configuration",
+        ]
+
         for section in required_sections:
             if section not in config:
                 return False, f"Missing required section: {section}"
-        
+
         return True, "Configuration is valid"
-        
+
     except Exception as e:
         return False, f"Configuration error: {str(e)}"

--- a/utils.py
+++ b/utils.py
@@ -6,44 +6,44 @@ logger = logging.getLogger("presidio-flask-api")
 
 cases = [
     # label, Estonian case name, English case name
-    ('n', 'nimetav', 'nominative'),
-    ('g', 'omastav', 'genitive'),
-    ('p', 'osastav', 'partitive'),
-    ('ill', 'sisseütlev', 'illative'),
-    ('in', 'seesütlev', 'inessive'),
-    ('el', 'seestütlev', 'elative'),
-    ('all', 'alaleütlev', 'allative'),
-    ('ad', 'alalütlev', 'adessive'),
-    ('abl', 'alaltütlev', 'ablative'),
-    ('tr', 'saav', 'translative'),
-    ('ter', 'rajav', 'terminative'),
-    ('es', 'olev', 'essive'),
-    ('ab', 'ilmaütlev', 'abessive'),
-    ('kom', 'kaasaütlev', 'comitative')
+    ("n", "nimetav", "nominative"),
+    ("g", "omastav", "genitive"),
+    ("p", "osastav", "partitive"),
+    ("ill", "sisseütlev", "illative"),
+    ("in", "seesütlev", "inessive"),
+    ("el", "seestütlev", "elative"),
+    ("all", "alaleütlev", "allative"),
+    ("ad", "alalütlev", "adessive"),
+    ("abl", "alaltütlev", "ablative"),
+    ("tr", "saav", "translative"),
+    ("ter", "rajav", "terminative"),
+    ("es", "olev", "essive"),
+    ("ab", "ilmaütlev", "abessive"),
+    ("kom", "kaasaütlev", "comitative"),
 ]
 
 
 def synthesize_word(word):
     """
     Synthesize all case forms for a single Estonian word
-    
+
     Args:
         word: Single word string
-        
+
     Returns:
         List of all case forms (singular + plural)
     """
     sing_rows = []
     plur_rows = []
-    
+
     for case, case_name_est, case_name_eng in cases:
-        sing_rows.extend(synthesize(word, 'sg ' + case, 'S'))
-        plur_rows.extend(synthesize(word, 'pl ' + case, 'S'))
-    
+        sing_rows.extend(synthesize(word, "sg " + case, "S"))
+        plur_rows.extend(synthesize(word, "pl " + case, "S"))
+
     all_forms = sing_rows + plur_rows
     # Remove duplicates and empty strings
     all_forms = [form for form in set(all_forms) if form.strip()]
-    
+
     logger.info(f"Synthesized {len(all_forms)} forms for word '{word}'")
     return all_forms
 
@@ -51,33 +51,33 @@ def synthesize_word(word):
 def synthesize_all(words):
     """
     Synthesize all case forms for a list of Estonian words
-    
+
     Args:
         words: List of word strings or single word string
-        
+
     Returns:
         List containing original words plus all synthesized case forms
     """
     if not words:
         return []
-    
+
     # Handle single word string
     if isinstance(words, str):
         words = [words]
-    
+
     result = []
-    
+
     for word in words:
         if not word or not isinstance(word, str):
             continue
-            
-        word = word.strip()
+
+        word = word.strip().lower()
         if not word:
             continue
-        
+
         # Add original word
         result.append(word)
-        
+
         # Add all synthesized forms
         try:
             synthesized = synthesize_word(word)
@@ -85,7 +85,7 @@ def synthesize_all(words):
         except Exception as e:
             logger.warning(f"Could not synthesize word '{word}': {e}")
             # Continue with just the original word
-    
+
     # Remove duplicates while preserving order
     seen = set()
     unique_result = []
@@ -94,6 +94,8 @@ def synthesize_all(words):
         if item_lower not in seen:
             seen.add(item_lower)
             unique_result.append(item)
-    
-    logger.info(f"Total words after synthesis: {len(unique_result)} (from {len(words)} original)")
+
+    logger.info(
+        f"Total words after synthesis: {len(unique_result)} (from {len(words)} original)"
+    )
     return unique_result


### PR DESCRIPTION
Updated docs and readme accordingly. 
Anonymize endpoint expects array of strings as an input instead of a single string. 
output is now also array of responses. 
Before input: 
```
{
  "text": "Minu nimi on Jaan Tamm",
  "language": "xx"
}
```
Now: 
```
{
  "texts": ["Minu nimi on Jaan Tamm", "Mari Mets elab Tallinnas"],
  "language": "xx"
}
```
Response format before: 
```
{
  "text": "Minu nimi on [ISIK]",
  "items": [...]
}
```
Response format now: 
```
{
  "results": [
    {
      "text": "Minu nimi on [ISIK]",
      "items": [...]
    },
    {
      "text": "[ISIK] elab Tallinnas",
      "items": [...]
    }
  ]
}
```